### PR TITLE
STORES風デザインへのリニューアル

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };


### PR DESCRIPTION
## 概要
Entertainment Connection SiteをSTORES.funのデザインに合わせてリニューアルしました。

## 変更内容

### 🎨 デザイン変更
- **ヒーローセクション**: STORES風のキャッチコピーとレイアウトに変更
  - 「あらゆるエンタメの売上成長に。」をメインコピーに
  - Welcome sectionを追加してサービスアイコンを表示

- **サービス一覧**: カード型レイアウトでエンタメ業界向けサービスを整理
  - 3つのカテゴリー: 運営コスト削減、販売チャネル拡充、ファン関係性強化
  - 各サービスにグラデーション背景とアイコンを追加

- **料金プラン**: STORES風の3段階プライシング
  - フリープラン (¥0)
  - スタンダードプラン (¥9,800/月)
  - カスタムプラン

- **企業実績**: ロゴマーキーとサクセスストーリーを追加
  - エンタメ業界の主要企業ロゴを表示
  - 具体的な成功事例を数値付きで紹介

- **FAQ**: Radix UI Accordionを使用したアコーディオン式FAQ
  - STORES風のサポートセクションを追加
  - 3つの問い合わせ方法を提示

### 🐛 バグ修正
- Radix UI Accordionの実装エラーを修正
- 欠落していた`accordion.tsx`コンポーネントを追加
- TypeScriptビルドエラーを解決

## テスト
- ローカルビルド: ✅ 成功
- TypeScriptチェック: ✅ パス
- Netlifyビルド: 修正済み

## スクリーンショット
（デプロイ後に追加予定）

🤖 Generated with [Claude Code](https://claude.ai/code)